### PR TITLE
Feature/rbac role change

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -81,3 +81,6 @@ class UserListResponse(BaseModel):
     total: int = Field(..., example=100)
     page: int = Field(..., example=1)
     size: int = Field(..., example=10)
+
+class RoleChangeRequest(BaseModel):
+    role: UserRole

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -14,6 +14,7 @@ from app.schemas.user_schemas import UserCreate, UserUpdate
 from app.utils.nickname_gen import generate_nickname
 from app.utils.security import generate_verification_token, hash_password, verify_password
 from app.services.email_service import EmailService
+from typing import TYPE_CHECKING
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
@@ -299,3 +300,16 @@ class UserService:
             logger.error(f"Error unlocking user {user_id}: {e}")
             await session.rollback()
             return False
+
+    @staticmethod
+    async def change_role(db: "AsyncSession", user_id: "UUID", new_role: "UserRole"):
+        """
+        Change a user's role. Returns the updated user or None if not found.
+        """
+        user = await UserService.get_by_id(db, user_id)
+        if not user:
+            return None
+        user.role = new_role
+        await db.commit()
+        await db.refresh(user)
+        return user

--- a/tests/test_rbac_change_role.py
+++ b/tests/test_rbac_change_role.py
@@ -1,0 +1,41 @@
+from app.models.user_model import UserRole
+
+PASSWORD = "MySuperPassword$1234"  # same default used by the other tests/fixtures
+
+def _auth_headers(client, email: str, password: str):
+    """Log in and return Authorization headers."""
+    r = client.post("/login/", data={"username": email, "password": password})
+    assert r.status_code == 200, f"login failed for {email}: {r.status_code} {r.text}"
+    token = r.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+def test_admin_can_change_any_role(client, admin_user, user):
+    """ADMIN can assign any role (e.g., set AUTHENTICATED user -> MANAGER)."""
+    headers = _auth_headers(client, admin_user.email, PASSWORD)
+    r = client.patch(f"/users/{user.id}/role", json={"role": "MANAGER"}, headers=headers)
+    assert r.status_code == 200
+    # be tolerant of how role is serialized in the response
+    assert "MANAGER" in str(r.json().get("role"))
+
+def test_manager_cannot_assign_admin(client, manager_user, user):
+    """MANAGER cannot assign ADMIN to anyone."""
+    headers = _auth_headers(client, manager_user.email, PASSWORD)
+    r = client.patch(f"/users/{user.id}/role", json={"role": "ADMIN"}, headers=headers)
+    assert r.status_code == 403
+
+def test_manager_cannot_change_admin_user(client, manager_user, admin_user):
+    """MANAGER cannot change an ADMIN user's role at all."""
+    headers = _auth_headers(client, manager_user.email, PASSWORD)
+    r = client.patch(f"/users/{admin_user.id}/role", json={"role": "MANAGER"}, headers=headers)
+    assert r.status_code == 403
+
+def test_noop_same_role_returns_200(client, admin_user, user):
+    """Setting the same role again should be a no-op but still 200."""
+    headers = _auth_headers(client, admin_user.email, PASSWORD)
+    # first change to MANAGER
+    r1 = client.patch(f"/users/{user.id}/role", json={"role": "MANAGER"}, headers=headers)
+    assert r1.status_code == 200
+    # same role again -> should still be 200 and unchanged
+    r2 = client.patch(f"/users/{user.id}/role", json={"role": "MANAGER"}, headers=headers)
+    assert r2.status_code == 200
+    assert "MANAGER" in str(r2.json().get("role"))


### PR DESCRIPTION
What’s new
RBAC endpoint: PATCH /users/{user_id}/role

ADMIN → can change any user to any role.

MANAGER → cannot assign ADMIN and cannot change an ADMIN user.

No-op changes (same role) return 200 with the current user payload.

Returns 403 when forbidden, 404 when user not found.

Auth plumbing: OAuth2PasswordBearer(tokenUrl="/login/") and login route at /login/ to avoid 307 redirects in tests/clients.

Resilient current_user handling: Normalize dict/JWT/object into a real DB user before processing.

Why
Adds a simple, auditable way to manage roles with clear guardrails for managers vs admins.

How to use (manual test)
bash
Copy
Edit
# Login (form-encoded)
curl -X POST http://localhost:8000/login/ \
  -d "username=admin@example.com" -d "password=MySuperPassword$1234"

# Use the token to promote a user to MANAGER
curl -X PATCH http://localhost:8000/users/<user-id>/role \
  -H "Authorization: Bearer <TOKEN>" \
  -H "Content-Type: application/json" \
  -d '{"role":"MANAGER"}'
Tests
Added 4 API tests in tests/test_rbac_change_role.py:

admin can change any role

manager cannot assign admin

manager cannot change an admin user

setting the same role is a no-op (still 200)

Full suite: 101/101 passing locally and in CI.

Notes
No DB schema changes / migrations.

Backwards compatible; existing endpoints untouched.